### PR TITLE
Register onopen callback and emit 'open' event when connection is established.

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ WebsocketStream.prototype.onClose = function(err) {
   this.emit('end')
 }
 
-WebsocketStream.prototype.onClose = function(err) {
+WebsocketStream.prototype.onOpen = function(err) {
   this.emit('open')
 }
 


### PR DESCRIPTION
Register onopen callback and emit 'open' event when connection is established.

```
var websocket = require('websocket-stream')
var ws = websocket('ws://realtimecats.com')

// case #1
ws.write('stuff')
// fails with the following DOM Exception ( http://stackoverflow.com/a/14733149/1524161 ):
// Uncaught Error: INVALID_STATE_ERR: DOM Exception 11 bundle.js:1515
// WebsocketStream.write bundle.js:1515
// (anonymous function) bundle.js:1531
// require.modules.(anonymous function) bundle.js:182
// require bundle.js:8
// (anonymous function) bundle.js:1550
// (anonymous function) bundle.js:1551

// case #2
ws.on('open', function () {
    console.log('connection is established, sending stuff to server'):
    ws.write('stuff');
});
// works
```
