### PR TITLE
fix error passing options to browser websocket constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ function WebsocketStream(server, options) {
     this.ws.on('open', this.onOpen.bind(this))
     if (this.ws.readyState === 1) this._open = true
   } else {
-    this.ws = new WebSocketPoly(server, this.options)
+    var opts = (process.title === 'browser') ? this.options.protocol : this.options
+    this.ws = new WebSocketPoly(server, opts)
     this.ws.binaryType = this.options.binaryType || 'arraybuffer'
     this.ws.onmessage = this.onMessage.bind(this)
     this.ws.onerror = this.onError.bind(this)


### PR DESCRIPTION
this might be kind of ugly, but seems like a simple solution [(for this error)?](https://github.com/maxogden/websocket-stream/pull/28#issuecomment-36837407)
