### PR TITLE
Fix a bug that caused a crash if a websocket server sent a empty string.

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,8 @@ module.exports.WebsocketStream = WebsocketStream
 
 WebsocketStream.prototype.onMessage = function(e) {
   var data = e
-  if (data.data) data = data.data
-  
+  if (typeof data.data !== 'undefined') data = data.data
+
   // type must be a Typed Array (ArrayBufferView)
   var type = this.options.type
   if (type && data instanceof ArrayBuffer) data = new type(data)


### PR DESCRIPTION
It would try to queue the websocket response object if the server sent an empty string causing an 'invalid data' exception to be thrown.

```
net.js:614
    throw new TypeError('invalid data');
          ^
TypeError: invalid data
  at WriteStream.Socket.write (net.js:614:11)
  at Stream.ondata (stream.js:51:26)
  at Stream.EventEmitter.emit (events.js:95:17)
  at drain (/Users/jnordberg/Development/ingress/node_modules/websocket-stream/node_modules/through/index.js:36:16)
  at Stream.stream.queue.stream.push (/Users/jnordberg/Development/ingress/node_modules/websocket-stream/node_modules/through/index.js:45:5)
  at WebsocketStream.onMessage (/Users/jnordberg/Development/ingress/node_modules/websocket-stream/index.js:45:15)
  at WebSocket.onMessage (/Users/jnordberg/Development/ingress/node_modules/ws/lib/WebSocket.js:360:18)
  at WebSocket.EventEmitter.emit (events.js:98:17)
  at Receiver.self._receiver.ontext (/Users/jnordberg/Development/ingress/node_modules/ws/lib/WebSocket.js:697:10)
  at Receiver.opcodes.1.finish (/Users/jnordberg/Development/ingress/node_modules/ws/lib/Receiver.js:397:14)
  at /Users/jnordberg/Development/ingress/node_modules/ws/lib/Receiver.js:384:31
  at Receiver.expectData (/Users/jnordberg/Development/ingress/node_modules/ws/lib/Receiver.js:153:5)
  at Receiver.opcodes.1.getData (/Users/jnordberg/Development/ingress/node_modules/ws/lib/Receiver.js:383:14)
  at Receiver.opcodes.1.start (/Users/jnordberg/Development/ingress/node_modules/ws/lib/Receiver.js:355:30)
  at Receiver.processPacket (/Users/jnordberg/Development/ingress/node_modules/ws/lib/Receiver.js:217:19)
  at Receiver.add (/Users/jnordberg/Development/ingress/node_modules/ws/lib/Receiver.js:93:24)
  at Socket.firstHandler (/Users/jnordberg/Development/ingress/node_modules/ws/lib/WebSocket.js:678:22)
  at Socket.EventEmitter.emit (events.js:95:17)
  at Socket.<anonymous> (_stream_readable.js:746:14)
  at Socket.EventEmitter.emit (events.js:92:17)
  at emitReadable_ (_stream_readable.js:408:10)
  at emitReadable (_stream_readable.js:404:5)
  at readableAddChunk (_stream_readable.js:165:9)
  at Socket.Readable.push (_stream_readable.js:127:10)
  at TCP.onread (net.js:528:21)
```
