### PR TITLE
emit "connect" event, like net does

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ function WebSocketStream(target, protocols) {
   function onready() {
     stream.setReadable(proxy)
     stream.setWritable(proxy)
+    stream.emit('connect')
   }
   
   function onclose() {


### PR DESCRIPTION
Emit the connect event when the handshake is complete, and we know for sure that we have a good connection. This is the same behavior as tcp streams have in node's net module, and is required to be used with [reconnect-core](https://github.com/juliangruber/reconnect-core)
