### PR TITLE
Working destroy method

### DIFF
--- a/test.js
+++ b/test.js
@@ -71,3 +71,23 @@ test('passes options to websocket constructor', function(t) {
   });
 
 });
+
+
+test('destroy', function(t) {
+  t.plan(1)
+
+  echo.start(function() {
+    var client = websocket(echo.url, echo.options)
+
+    client.on('close', function() {
+      echo.stop(function() {
+        t.pass('destroyed')
+      })
+    })
+
+    setTimeout(function() {
+      client.destroy();
+    }, 200);
+  });
+
+});


### PR DESCRIPTION
The current destroy() method provided by duplexify does not destroy the underlining socket.
