### PR TITLE
Closed by other party error

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function WebSocketStream(target, protocols) {
   socket.addEventListener("error", onerror)
   socket.addEventListener("message", onmessage)
 
-  proxy.destroy = destroy;
+  proxy.on('close', destroy);
 
   function socketWrite(chunk, enc, next) {
     socket.send(chunk, next)
@@ -53,10 +53,6 @@ function WebSocketStream(target, protocols) {
   }
 
   function onerror(err) {
-    if (stream === proxy && err) {
-      stream.emit('error', err)
-    }
-
     stream.destroy(err)
   }
 

--- a/index.js
+++ b/index.js
@@ -34,12 +34,7 @@ function WebSocketStream(target, protocols) {
   proxy.destroy = destroy;
 
   function socketWrite(chunk, enc, next) {
-    try {
-      socket.send(chunk)
-      next()
-    } catch(err) {
-      onerror(err)
-    }
+    socket.send(chunk, next)
   }
 
   function socketEnd(done) {

--- a/index.js
+++ b/index.js
@@ -34,8 +34,12 @@ function WebSocketStream(target, protocols) {
   proxy.destroy = destroy;
 
   function socketWrite(chunk, enc, next) {
-    socket.send(chunk)
-    next()
+    try {
+      socket.send(chunk)
+      next()
+    } catch(err) {
+      onerror(err)
+    }
   }
 
   function socketEnd(done) {
@@ -54,6 +58,10 @@ function WebSocketStream(target, protocols) {
   }
 
   function onerror(err) {
+    if (stream === proxy && err) {
+      stream.emit('error', err)
+    }
+
     stream.destroy(err)
   }
 

--- a/test-client.js
+++ b/test-client.js
@@ -1,4 +1,4 @@
-var ws = require('websocket-stream')
+var ws = require('./')
 var test = require('tape')
 
 test('echo works', function(t) {
@@ -8,5 +8,5 @@ test('echo works', function(t) {
     stream.destroy()
     t.end()
   })
-  stream.write(new Buffer('hello'))  
+  stream.write(new Buffer('hello'))
 })


### PR DESCRIPTION
If a client dies, and the server has yet to still emit 'close',
`socket.send()` throws an exception which is not catched and handled
properly. Moreover the `onerror` handler was not considering the server
case, and it was swallowing the errors.