### PR TITLE
Browser field should alias to a relative file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   "optionalDependencies": {},
   "browser": {
     "./echo-server.js": "./fake-server.js",
-    "./index.js": "stream.js"
+    "./index.js": "./stream.js"
   }
 }


### PR DESCRIPTION
This was breaking webpack builds because it was trying to load
a module called 'stream.js' instead of the file.