### PR TITLE
stream: use "open", not "connect"

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -56,7 +56,7 @@ function WebSocketStream(target, protocols) {
   function onready() {
     stream.setReadable(proxy)
     stream.setWritable(proxy)
-    stream.emit('connect')
+    stream.emit('open')
   }
 
   function onclose() {


### PR DESCRIPTION
This is more consistent with the typical stream wording of "open" / "close" and treating streams as pipes IMHO.

If not this PR, could we please add documentation of `"connect"` to the README?