### PR TITLE
fix failed test

### DIFF
--- a/test.js
+++ b/test.js
@@ -165,7 +165,7 @@ test('error on socket should forward it to pipe', function(t) {
         t.pass('error is called')
       })
     })
-    stream.socket.emit('error', 'Fake error')
+    stream.socket.emit('error', new Error('Fake error'))
   })
   server.listen(echo.port, clientConnect)
 })


### PR DESCRIPTION
current test was failed.

```
/tmp/websocket-stream/node_modules/tape/index.js:75
        throw err
              ^
TypeError: Cannot assign to read only property 'target' of Fake error
    at WebSocket.onError (/tmp/websocket-stream/node_modules/ws/lib/WebSocket.js:422:18)
    at WebSocket.emit (events.js:107:17)
    at WebSocketServer.<anonymous> (/tmp/websocket-stream/test.js:168:19)
    at WebSocketServer.emit (events.js:107:17)
    at /tmp/websocket-stream/node_modules/ws/lib/WebSocketServer.js:79:14
    at completeHybiUpgrade2 (/tmp/websocket-stream/node_modules/ws/lib/WebSocketServer.js:262:5)
    at completeHybiUpgrade1 (/tmp/websocket-stream/node_modules/ws/lib/WebSocketServer.js:287:13)
    at WebSocketServer.handleHybiUpgrade (/tmp/websocket-stream/node_modules/ws/lib/WebSocketServer.js:315:3)
    at WebSocketServer.handleUpgrade (/tmp/websocket-stream/node_modules/ws/lib/WebSocketServer.js:152:26)
    at Server.<anonymous> (/tmp/websocket-stream/node_modules/ws/lib/WebSocketServer.js:77:12)
npm ERR! Test failed.  See above for more details.
```

fix this using Error instead of string.