### PR TITLE
end the stream when the websocket closes

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "beefy": "^2.1.1",
     "browserify": "^5.11.1",
+    "concat-stream": "^1.4.7",
     "tape": "^2.14.0"
   },
   "optionalDependencies": {},

--- a/stream.js
+++ b/stream.js
@@ -60,6 +60,7 @@ function WebSocketStream(target, protocols) {
   }
 
   function onclose() {
+    stream.end();
     stream.destroy()
   }
 


### PR DESCRIPTION
When the remote end closes, there's no notification at the server side of the connection right now. This patch ends the stream when the remote end closes.

It might also be a good idea to have a `close` event to handle cleanup and such.