### PR TITLE
specify license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "websocket-stream",
   "version": "1.5.0",
+  "license": "BSD-2-Clause",
   "description": "Use websockets with the node streams API. Works in browser and node",
   "scripts": {
     "test": "node test.js",


### PR DESCRIPTION
ps. since you are using the BSD-2-Clause, you might like the shorter ISC license even more. Personally after using BSD-2-Clause, going for MIT, I ended up with the simplest/shortest of 'm which is ISC. Just fyi ;-)