### PR TITLE
Updated through to 2.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "duplexify": "^3.2.0",
     "inherits": "^2.0.1",
-    "through2": "^0.6.1",
+    "through2": "^2.0.0",
     "ws": "^0.8.0",
     "xtend": "^4.0.0"
   },


### PR DESCRIPTION
The reason is that I would like this module to not depend on readable-stream 0.x.

I propose to release this as 2.1.0.