### PR TITLE
Fix duplicate stream events.

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,8 +12,10 @@ function Server(opts, cb) {
 
   WebSocketServer.call(this, opts)
 
+  var proxied = false
   this.on('newListener', function(event) {
-    if (event === 'stream') {
+    if (!proxied && event === 'stream') {
+      proxied = true
       this.on('connection', function(conn) {
         this.emit('stream', stream(conn))
       })

--- a/test.js
+++ b/test.js
@@ -188,3 +188,21 @@ test('stream end', function(t) {
     w.end('pizza cats\n')
   })
 })
+
+test('stream handlers should fire once per connection', function(t) {
+  t.plan(1)
+
+  var server = http.createServer()
+  var wss = websocket.createServer({ server: server }, function() {
+    server.close(function() {
+      t.equal(m, 1)
+    })
+  })
+
+  var m = 0
+  wss.on('stream', function() { m++ })
+  server.listen(0, function() {
+    var w = websocket('ws://localhost:' + server.address().port)
+    w.end('pizza cats\n')
+  })
+})


### PR DESCRIPTION
Thanks for this very convenient library!

Previously, a single `'connection'` event could trigger multiple `'stream'`
events (when multiple handlers were added). Now each connection will
only ever trigger it once.

An alternate implementation would be to always proxy the event, i.e. not
wait for the first `'stream'` handler to be attached; but this felt less in line
with the existing implementation. Let me know which you prefer.