### PR TITLE
Add ws fallback for browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "optionalDependencies": {},
   "browser": {
     "./echo-server.js": "./fake-server.js",
-    "./index.js": "./stream.js"
+    "./index.js": "./stream.js",
+    "ws": "./ws-fallback.js"
   },
   "bugs": {
     "url": "https://github.com/maxogden/websocket-stream/issues"

--- a/ws-fallback.js
+++ b/ws-fallback.js
@@ -1,0 +1,1 @@
+module.exports = window.WebSocket || window.MozWebSocket


### PR DESCRIPTION
This should be logically equivalent to the previous fallback in `ws`,
which was removed in [this commit](https://github.com/websockets/ws/commit/e54d45fbab3b19c2940e9057ce1e7b8f105873e0)