### PR TITLE
check for global.MozWebSocket in native browser case

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -8,7 +8,7 @@ function WebSocketStream(target, protocols, options) {
   var stream, socket
 
   var isBrowser = process.title === 'browser'
-  var isNative = !!global.WebSocket
+  var isNative = !!(global.WebSocket || global.MozWebSocket)
   var socketWrite = isBrowser ? socketWriteBrowser : socketWriteNode
   var proxy = through.obj(socketWrite, socketEnd)
 


### PR DESCRIPTION
If `ws-fallback.js` is used for the browserified code, shouldn't the `isNative` check also check for that?