### PR TITLE
WebSocket and MozWebSocket first and if not defined then tries to export from window

### DIFF
--- a/ws-fallback.js
+++ b/ws-fallback.js
@@ -1,1 +1,1 @@
-module.exports = window.WebSocket || window.MozWebSocket
+module.exports = WebSocket || MozWebSocket || window.WebSocket || window.MozWebSocket


### PR DESCRIPTION
this should fix maxogden/websocket-stream/issues/90, as it exports WebSocket and MozWebSocket first and if not defined then tries to export from window.