### PR TITLE
Add support for passing options to ws.send()

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -58,8 +58,23 @@ function WebSocketStream(target, protocols, options) {
 
   proxy.on('close', destroy)
 
+  // for server only
+  // The value of the arguemnt called 'binary' is decided on a chunk by chunk basis by default.
+  // socket.send() modify the passed in options argument.
+  // Hence, reusing the same object on each send call results in a situation, where
+  // any unpassed paramters will be set based on the very first chunk; To overcome this
+  // a new object literal is needed for each invocation of send
+  function sendOptions() {
+    return {
+      binary: options.binary,
+      mask: options.mask,
+      fin: options.fin,
+      compress: options.compress
+    }
+  }
+
   function socketWriteNode(chunk, enc, next) {
-    socket.send(chunk, next)
+    socket.send(chunk, sendOptions(), next)
   }
 
   function socketWriteBrowser(chunk, enc, next) {

--- a/stream.js
+++ b/stream.js
@@ -58,12 +58,9 @@ function WebSocketStream(target, protocols, options) {
 
   proxy.on('close', destroy)
 
-  // for server only
-  // The value of the arguemnt called 'binary' is decided on a chunk by chunk basis by default.
-  // socket.send() modify the passed in options argument.
-  // Hence, reusing the same object on each send call results in a situation, where
-  // any unpassed paramters will be set based on the very first chunk; To overcome this
-  // a new object literal is needed for each invocation of send
+  // server only: socket.send() mutates the passed-in options argument
+  // this helper creates a new options argument for each invocation of socket.send()
+  // see: https://github.com/maxogden/websocket-stream/pull/94#discussion_r71310808
   function sendOptions() {
     return {
       binary: options.binary,


### PR DESCRIPTION
Hi,

I came across a situation, #https://github.com/mcollina/aedes/issues/61, when it was necessary to force the underlying node websocket to send all the data in binary data frames. With the change I made, someone can pass the following extra arguments to websocket-stream as options: binary, mask, fin, compress. These arguments then will be passed to ws.send() on every invocation.
