### PR TITLE
Fix the binary option behavior in the browser as well.

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -61,7 +61,7 @@ function WebSocketStream(target, protocols, options) {
   var coerceToBuffer = options.binary || options.binary === undefined
 
   function socketWriteNode(chunk, enc, next) {
-    if (coerceToBuffer && !(chunk instanceof Buffer)) {
+    if (coerceToBuffer && typeof chunk === 'string') {
       chunk = new Buffer(chunk, 'utf8')
     }
     socket.send(chunk, next)
@@ -71,6 +71,10 @@ function WebSocketStream(target, protocols, options) {
     if (socket.bufferedAmount > bufferSize) {
       setTimeout(socketWriteBrowser, bufferTimeout, chunk, enc, next)
       return
+    }
+
+    if (coerceToBuffer && typeof chunk === 'string') {
+      chunk = new Buffer(chunk, 'utf8')
     }
 
     try {

--- a/test-client.js
+++ b/test-client.js
@@ -47,3 +47,14 @@ test('with bare WebSocket, binary only', function (t) {
     t.end()
   }
 })
+
+test('coerce client data as binary', function(t) {
+  var stream = ws('ws://localhost:8346', { binary: true })
+  stream.on('data', function(o) {
+    t.ok(Buffer.isBuffer(o), 'is buffer')
+    t.equal(o.toString(), 'success', 'success!')
+    stream.destroy()
+    t.end()
+  })
+  stream.write('hello')
+})

--- a/test-server.js
+++ b/test-server.js
@@ -1,6 +1,7 @@
 var http = require('http')
 var websocket = require('./')
 var echo = require('./echo-server.js')
+var WebSocketServer = require('ws').Server
 
 echo.start(function(){
   console.log('echo server is running')
@@ -29,3 +30,26 @@ forBare({
 forBare({
   port: 8345
 })
+
+function checkIfDataIsBinary () {
+  var server = http.createServer()
+  var wss = new WebSocketServer({
+    server: server
+  })
+
+  server.listen(8346)
+
+  wss.on('connection', waitFor)
+
+  function waitFor (ws) {
+    ws.on('message', function (data) {
+      if (!Buffer.isBuffer(data)) {
+        ws.send(new Buffer('fail'))
+      } else {
+        ws.send(new Buffer('success'))
+      }
+    })
+  }
+}
+
+checkIfDataIsBinary()


### PR DESCRIPTION
As title, option `binary: true`  that works in the browser as well.

Fixes https://github.com/mqttjs/MQTT.js/issues/482
Fixes https://github.com/mqttjs/MQTT.js/issues/480
Fixes https://github.com/mqttjs/MQTT.js/issues/465

Probably we should seek a better way of dealing with binary data altogether.

cc @mafintosh @maxogden 