### PR TITLE
Set `protocols` based on the field in `options`

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -17,8 +17,8 @@ function WebSocketStream(target, protocols, options) {
     options = protocols
     protocols = null
 
-    if (typeof options.protocol === 'string') {
-      protocols = [options.protocol];
+    if (typeof options.protocol === 'string' || Array.isArray(object.protocol)) {
+      protocols = options.protocol;
     }
   }
 

--- a/stream.js
+++ b/stream.js
@@ -16,6 +16,10 @@ function WebSocketStream(target, protocols, options) {
     // accept the "options" Object as the 2nd argument
     options = protocols
     protocols = null
+
+    if (typeof options.protocol === 'string') {
+      protocols = [options.protocol];
+    }
   }
 
   if (!options) options = {}


### PR DESCRIPTION
Resolves #102.

This sets the `protocols` variable based on the `protocol` field from the `options` object. I am not certain if this is the right field; it is the one used by `mqtt.js` which is what I need it for, but may not be generally the correct one.