### PR TITLE
Update ws to version 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "inherits": "^2.0.1",
     "readable-stream": "^2.2.0",
     "safe-buffer": "^5.0.1",
-    "ws": "^2.2.3",
+    "ws": "^3.0.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,8 @@ Using the [`ws`](http://npmjs.org/ws) module you can make a websocket server and
 var websocket = require('websocket-stream')
 var wss = websocket.createServer({server: someHTTPServer}, handle)
 
-function handle(stream) {
+function handle(stream, request) {
+  // `request` is the upgrade request sent by the client.
   fs.createReadStream('bigdata.json').pipe(stream)
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ We recommend disabling the [per message deflate
 extension](https://tools.ietf.org/html/rfc7692) to achieve the best
 throughput.
 
-Default: `true`
+Default: `true` on the client, `false` on the server.
 
 Example:
 
@@ -65,7 +65,7 @@ var ws = websocket('ws://realtimecats.com', {
 })
 ```
 
-Beware that this is the only one option you cannot set on the client. You must set it on the server and this will be negotiated with the client.
+Beware that this option is ignored by browser clients. To make sure that permessage-deflate is never used, disable it on the server.
 
 ##### Other options
 

--- a/server.js
+++ b/server.js
@@ -11,8 +11,8 @@ class Server extends WebSocketServer{
     this.on('newListener', function(event) {
       if (!proxied && event === 'stream') {
         proxied = true
-        this.on('connection', function(conn) {
-          this.emit('stream', stream(conn, opts))
+        this.on('connection', function(conn, req) {
+          this.emit('stream', stream(conn, opts), req)
         })
       }
     })

--- a/test.js
+++ b/test.js
@@ -193,10 +193,10 @@ test('error on socket should forward it to pipe', function(t) {
 
 test('stream end', function(t) {
   t.plan(1)
- 
+
   var server = http.createServer()
   websocket.createServer({ server: server }, handle)
- 
+
   function handle (stream) {
     stream.pipe(concat(function (body) {
       t.equal(body.toString(), 'pizza cats\n')
@@ -210,7 +210,7 @@ test('stream end', function(t) {
 })
 
 test('stream handlers should fire once per connection', function(t) {
-  t.plan(1)
+  t.plan(2)
 
   var server = http.createServer()
   var wss = websocket.createServer({ server: server }, function() {
@@ -220,7 +220,10 @@ test('stream handlers should fire once per connection', function(t) {
   })
 
   var m = 0
-  wss.on('stream', function() { m++ })
+  wss.on('stream', function(stream, request) {
+    t.ok(request instanceof http.IncomingMessage)
+    m++
+  })
   server.listen(0, function() {
     var w = websocket('ws://localhost:' + server.address().port)
     w.end('pizza cats\n')


### PR DESCRIPTION
Here is a list of the breaking changes in `ws@3`: https://github.com/websockets/ws/releases/tag/3.0.0.

The most important is that the `http.IncomingMessage` object is no longer attached to the `WebSocket` object and is instead passed as the second argument to the `'connection'` event.
It seems that websocket-stream does not rely on the removed `upgradeReq` property so this should be a safe and easy update.

One thing to keep in mind is that `stream.socket.upgradeReq` is gone so this might be a breaking change.