### PR TITLE
don't crash on socket error 

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -83,6 +83,8 @@ function WebSocketStream(target, protocols, options) {
   socket.onerror = onerror
   socket.onmessage = onmessage
 
+  proxy.on('error', function(){})
+
   proxy.on('close', destroy)
 
   var coerceToBuffer = !options.objectMode


### PR DESCRIPTION
Don't crash, even if user does not specify a stream error handler.

