### PR TITLE
Avoid using deprecated Buffer constructor

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -96,7 +96,7 @@ function WebSocketStream(target, protocols, options) {
     }
 
     if (coerceToBuffer && typeof chunk === 'string') {
-      chunk = new Buffer(chunk, 'utf8')
+      chunk = Buffer.from(chunk, 'utf8')
     }
     socket.send(chunk, next)
   }
@@ -108,7 +108,7 @@ function WebSocketStream(target, protocols, options) {
     }
 
     if (coerceToBuffer && typeof chunk === 'string') {
-      chunk = new Buffer(chunk, 'utf8')
+      chunk = Buffer.from(chunk, 'utf8')
     }
 
     try {

--- a/test-server.js
+++ b/test-server.js
@@ -2,6 +2,7 @@ var http = require('http')
 var websocket = require('./')
 var echo = require('./echo-server.js')
 var WebSocketServer = require('ws').Server
+var Buffer = require('safe-buffer').Buffer
 
 echo.start(function(){
   console.log('echo server is running')
@@ -44,9 +45,9 @@ function checkIfDataIsBinary () {
   function waitFor (ws) {
     ws.on('message', function (data) {
       if (!Buffer.isBuffer(data)) {
-        ws.send(new Buffer('fail'))
+        ws.send(Buffer.from('fail'))
       } else {
-        ws.send(new Buffer('success'))
+        ws.send(Buffer.from('success'))
       }
     })
   }


### PR DESCRIPTION
`safe-buffer` is already used and provides `Buffer.from` polyfill, so just use `Buffer.from` directly to avoid hitting deprecated API.

Refs: https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor

Tracking: https://github.com/nodejs/node/issues/19079

This was overlooked in c9312bd24d08271687d76da0fe3c83493871cf61.

/cc @mcollina 