### PR TITLE
If options is supplied and has a headers property, make sure to pass through the custom headers.

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -60,7 +60,9 @@ function WebSocketStream(target, protocols, options) {
   } else {
     // special constructor treatment for native websockets in browsers, see
     // https://github.com/maxogden/websocket-stream/issues/82
-    if (isNative && isBrowser) {
+    // additionally, if options is supplied and contains headers property, keep initialise with protocols & options
+    let hasAdditionalHeaders = !!(options && options.headers);
+    if (isNative && isBrowser && !hasAdditionalHeaders) {
       socket = new WS(target, protocols)
     } else {
       socket = new WS(target, protocols, options)


### PR DESCRIPTION
Fixes issue in React Native, detailed here:
https://github.com/mqttjs/MQTT.js/issues/856
and here:
https://github.com/aws/aws-iot-device-sdk-js/issues/169

If custom headers are passed in to websocket-stream, they should be used when creating the websocket.