### PR TITLE
types: improve typing of ClientOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for websocket-stream 5.3
+// Type definitions for websocket-stream 5.5
 // Project: https://github.com/maxogden/websocket-stream#readme
 // Original definitions by: Ben Burns <https://github.com/benjamincburns>
 
@@ -21,7 +21,14 @@ declare namespace WebSocketStream {
   function createServer(opts?: WebSocket.ServerOptions, callback?: () => void): Server;
 }
 
-declare function WebSocketStream(target: string | WebSocket, options?: WebSocket.ClientOptions): WebSocketStream.WebSocketDuplex;
-declare function WebSocketStream(target: string | WebSocket, protocols?: string | string[], options?: WebSocket.ClientOptions): WebSocketStream.WebSocketDuplex;
+interface ClientOptions extends WebSocket.ClientOptions {
+  browserBufferSize?: number;
+  browserBufferTimeout?: number;
+  objectMode?: boolean;
+  binary?: boolean;
+}
+
+declare function WebSocketStream(target: string | WebSocket, options?: ClientOptions): WebSocketStream.WebSocketDuplex;
+declare function WebSocketStream(target: string | WebSocket, protocols?: string | string[], options?: ClientOptions): WebSocketStream.WebSocketDuplex;
 
 export = WebSocketStream;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "email": "max@maxogden.com"
   },
   "dependencies": {
+    "@types/ws": "^6.0.1",
     "duplexify": "^3.5.1",
     "inherits": "^2.0.1",
     "readable-stream": "^2.3.3",
@@ -32,7 +33,6 @@
   },
   "devDependencies": {
     "@types/node": "^11.13.4",
-    "@types/ws": "^6.0.1",
     "beefy": "^2.1.8",
     "browserify": "^16.2.3",
     "concat-stream": "^1.6.2",


### PR DESCRIPTION
Also, this commit moves @types/ws from devDependencies to dependencies.
This is required for correct type checking in TypeScript projects,
because @types/ws is being exposed as part of public API in this package's
typing. Without this, TypeScript projects with --noImplicitAny setting
would have compilation errors.