### PR TITLE
fix(security): Bump ws to latest supportable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,19 +27,18 @@
     "inherits": "^2.0.1",
     "readable-stream": "^2.3.3",
     "safe-buffer": "^5.1.2",
-    "ws": "^3.2.0",
+    "ws": "^7.5.10",
     "xtend": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^11.13.4",
     "@types/ws": "^6.0.1",
-    "beefy": "^2.1.8",
+    "beefy": "^1.1.0",
     "browserify": "^16.2.3",
     "concat-stream": "^1.6.2",
     "tape": "^4.9.1",
     "typescript": "^3.4.3"
   },
-  "optionalDependencies": {},
   "browser": {
     "./echo-server.js": "./fake-server.js",
     "./index.js": "./stream.js",


### PR DESCRIPTION
CVE-2024-37890 was located in the ws package. They have patched this in the head of ws package, and backported it into the 7.x version list.

This PR Bumps ws to 7.5.10, which is the newest version of 7.x. Upon testing using npm test, 8.x versions were found to not work as there are breaking changes in the interface. However 7.5.10 passes the test suite.

Ref: issue #165